### PR TITLE
Js date picker

### DIFF
--- a/books/forms.py
+++ b/books/forms.py
@@ -5,7 +5,7 @@ from .models import UserBook, BookNote
 
 
 class DateInput(forms.DateInput):
-    input_type = 'date'
+    input_type = 'text'
 
 
 class UserBookForm(ModelForm):

--- a/books/forms.py
+++ b/books/forms.py
@@ -4,6 +4,10 @@ from django.forms import ModelForm
 from .models import UserBook, BookNote
 
 
+class DateInput(forms.DateInput):
+    input_type = 'date'
+
+
 class UserBookForm(ModelForm):
 
     # def __init__(self, *args, **kwargs):
@@ -12,4 +16,6 @@ class UserBookForm(ModelForm):
     class Meta:
         model = UserBook
         fields = ['status', 'completed']
-        completed = forms.DateTimeField()
+        widgets = {
+            'completed': DateInput(),
+        }

--- a/books/forms.py
+++ b/books/forms.py
@@ -4,10 +4,6 @@ from django.forms import ModelForm
 from .models import UserBook, BookNote
 
 
-class DateInput(forms.DateInput):
-    input_type = 'date'
-
-
 class UserBookForm(ModelForm):
 
     # def __init__(self, *args, **kwargs):
@@ -16,6 +12,4 @@ class UserBookForm(ModelForm):
     class Meta:
         model = UserBook
         fields = ['status', 'completed']
-        widgets = {
-            'completed': DateInput(),
-        }
+        completed = forms.DateTimeField()

--- a/myreadinglist/static/js/date_picker.js
+++ b/myreadinglist/static/js/date_picker.js
@@ -1,6 +1,0 @@
-// For JQuery UI Calendar
-$(function() {
-    $( "#id_completed" ).datepicker({
-        dateFormat: "yy-mm-dd"
-    });
-});

--- a/myreadinglist/static/js/date_picker.js
+++ b/myreadinglist/static/js/date_picker.js
@@ -1,0 +1,6 @@
+// For JQuery UI Calendar
+$(function() {
+    $( "#id_completed" ).datepicker({
+        dateFormat: "yy-mm-dd"
+    });
+});

--- a/myreadinglist/static/js/script.js
+++ b/myreadinglist/static/js/script.js
@@ -66,3 +66,9 @@ $(document).ready(function(){
     });
 
 });
+
+$(function() {
+    $( "#id_completed" ).datepicker({
+        dateFormat: "yy-mm-dd"
+    });
+});

--- a/myreadinglist/templates/base.html
+++ b/myreadinglist/templates/base.html
@@ -25,7 +25,6 @@
     <script src="{% static 'js/jquery_min.js' %}"></script>
     <link rel="stylesheet" href="//code.jquery.com/ui/1.8.24/themes/base/jquery-ui.css">
     <script src="//code.jquery.com/ui/1.8.24/jquery-ui.js"></script>
-    <script src="{% static 'js/date_picker.js' %}"></script>
     <script src="{% static 'js/jquery.autocomplete.js' %}"></script>
     <script src="{% static 'js/script.js' %}"></script>
     <link rel="stylesheet" type="text/css" href="{% static 'css/jquery.autocomplete.css' %}">

--- a/myreadinglist/templates/base.html
+++ b/myreadinglist/templates/base.html
@@ -23,14 +23,13 @@
     <script src="//cdn.muicss.com/mui-0.9.39/extra/mui-combined.min.js"></script>
     <script type="text/javascript" src="//books.google.com/books/previewlib.js"></script>
     <script src="{% static 'js/jquery_min.js' %}"></script>
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.8.24/themes/base/jquery-ui.css">
+    <script src="//code.jquery.com/ui/1.8.24/jquery-ui.js"></script>
+    <script src="{% static 'js/date_picker.js' %}"></script>
     <script src="{% static 'js/jquery.autocomplete.js' %}"></script>
     <script src="{% static 'js/script.js' %}"></script>
     <link rel="stylesheet" type="text/css" href="{% static 'css/jquery.autocomplete.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}">
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-    <script src="{% static 'js/date_picker.js' %}"></script>
   </head>
   <body>
     <header class="mui-appbar mui--z1">

--- a/myreadinglist/templates/base.html
+++ b/myreadinglist/templates/base.html
@@ -27,6 +27,10 @@
     <script src="{% static 'js/script.js' %}"></script>
     <link rel="stylesheet" type="text/css" href="{% static 'css/jquery.autocomplete.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}">
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <script src="{% static 'js/date_picker.js' %}"></script>
   </head>
   <body>
     <header class="mui-appbar mui--z1">


### PR DESCRIPTION
I used an older version of jquery/ui (1.8.24) to be compatible with the current local jquery_min.js (1.4.2)
The jquery/ui documentation says 1.8.24 is compatible with  jQuery 1.3.2 and newer.

Tested the new js calendar and existing booksearch on the following browser versions:
- Google Chrome Version 86.0.4240.75 (Official Build) (64-bit)
- Microsoft Edge Version 86.0.622.43 (Official build) (64-bit)
- Safari Version 12.1.2 (14607.3.9)